### PR TITLE
Improve Bash script in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ o,p
 Print USV characters by using a shell script with `bash`:
 
 ```bash
-#!/usr/local/bin/bash
+#!/usr/bin/env bash
 set -euf -o pipefail
 
 # USV example shell script that demonstrates the use of USV characters.


### PR DESCRIPTION
Hey :wave: just a small improvement for an example in the `README.md`

This PR changes the shebang of the exampthe script to increase portability by using `/usr/bin/env bash` instead of a static path to a bash executable, which might differ from various systems.