### PR TITLE
Update vi/vim advice

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Context:
 
 Editor notes:
 
-* [vi notes](doc/editors/vi/)
+* [vim notes](doc/editors/vi/)
 
 * [emacs notes](doc/editors/emacs/)
 
@@ -209,7 +209,7 @@ USV uses visible letter-width characters, and these are easy to view, select, co
 
 USV is intended to be easy to use and friendly to try.
 
-USV works with many kinds of data, and many kinds of editors. Any editor that can render the USV characters will work. We use vi, emacs, helix, Zed, VS Code, JEOTrains IDEs, Nova, TextMate, Sublime, Notepad++, etc.
+USV works with many kinds of data, and many kinds of editors. Any editor that can render the USV characters will work. We use vim, emacs, helix, Zed, VS Code, JEOTrains IDEs, Nova, TextMate, Sublime, Notepad++, etc.
 
 USV works with many kinds of tools. Any tool that can parse the USV characters will work. We use awk, sed, grep, rg, miller, etc.
 

--- a/doc/editors/vi/index.md
+++ b/doc/editors/vi/index.md
@@ -4,14 +4,15 @@ vim comes with most modern Linux and BSD distributions.
 
 ## Digraph characters
 
-To add digraph characters:
+To add digraphs for each USV character, add
 
 ```
-digraph rs 9246 us 9247
+digraph us 9247 rs 9246 gs 9245 fs 9244 es 9243 eo 9220
 ```
 
-This makes the characters easy to type directly in a .usv file, and easy to to type and read in source code.
+to your `~/.vimrc`
 
+Then when you want to type, for instance, the record separator character, in insert mode, type `<ctrl-k>rs`
 
 ## List hidden characters
 

--- a/doc/editors/vi/index.md
+++ b/doc/editors/vi/index.md
@@ -1,7 +1,6 @@
-# vi notes
+# vim notes
 
-vi is the POSIX standard editor that comes on all modern POSIX operating systems, including most Linux distributions.
-
+vim comes with most modern Linux and BSD distributions.
 
 ## Digraph characters
 
@@ -27,5 +26,3 @@ Later:
 ```
 :set nolist
 ```
-
-


### PR DESCRIPTION
Change most vi mentions to mentions of vim (modern vi), since only it supports digraphs.  The `:set list` advice still applies to traditional `vi` (namely `nvi`) if you want to set that advice apart.